### PR TITLE
Issue 11: Added the ability to resize the table and item view

### DIFF
--- a/internal/dynamo-browse/controllers/events.go
+++ b/internal/dynamo-browse/controllers/events.go
@@ -6,6 +6,10 @@ import (
 	"github.com/lmika/audax/internal/dynamo-browse/models"
 )
 
+type SetTableItemView struct {
+	ViewIndex int
+}
+
 type NewResultSet struct {
 	ResultSet     *models.ResultSet
 	currentFilter string

--- a/internal/dynamo-browse/ui/teamodels/dynamoitemedit/model.go
+++ b/internal/dynamo-browse/ui/teamodels/dynamoitemedit/model.go
@@ -107,3 +107,8 @@ func (m *Model) Resize(w, h int) layout.ResizingModel {
 func (m *Model) Visible() {
 	m.visible = true
 }
+
+func (m *Model) SetSubmodel(submodel tea.Model) {
+	m.submodel = submodel
+	m.Resize(m.w, m.h)
+}

--- a/internal/dynamo-browse/ui/teamodels/layout/boxsize.go
+++ b/internal/dynamo-browse/ui/teamodels/layout/boxsize.go
@@ -24,6 +24,21 @@ func (l equalSize) childSize(idx, cnt, available int) int {
 	return childrenHeight
 }
 
+func FirstChildFixedAt(size int) BoxSize {
+	return firstChildFixedAt{size}
+}
+
+type firstChildFixedAt struct {
+	firstChildSize int
+}
+
+func (l firstChildFixedAt) childSize(idx, cnt, available int) int {
+	if idx == 0 {
+		return l.firstChildSize
+	}
+	return (equalSize{}).childSize(idx, cnt-1, available-l.firstChildSize)
+}
+
 func LastChildFixedAt(size int) BoxSize {
 	return lastChildFixedAt{size}
 }

--- a/internal/dynamo-browse/ui/teamodels/layout/zstack.go
+++ b/internal/dynamo-browse/ui/teamodels/layout/zstack.go
@@ -1,0 +1,61 @@
+package layout
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/lmika/audax/internal/dynamo-browse/ui/teamodels/utils"
+)
+
+type ZStack struct {
+	visibleModel tea.Model
+	focusedModel tea.Model
+	otherModels  []tea.Model
+}
+
+func NewZStack(visibleModel tea.Model, focusedModel tea.Model, otherModels ...tea.Model) ZStack {
+	return ZStack{
+		visibleModel: visibleModel,
+		focusedModel: focusedModel,
+		otherModels:  otherModels,
+	}
+}
+
+func (vb ZStack) Init() tea.Cmd {
+	var cc utils.CmdCollector
+	cc.Collect(vb.visibleModel, vb.visibleModel.Init())
+	cc.Collect(vb.focusedModel, vb.focusedModel.Init())
+	for _, c := range vb.otherModels {
+		cc.Collect(c, c.Init())
+	}
+	return cc.Cmd()
+}
+
+func (vb ZStack) Update(msg tea.Msg) (m tea.Model, cmd tea.Cmd) {
+	switch msg.(type) {
+	case tea.KeyMsg:
+		// Only the focused model gets keyboard events
+		vb.focusedModel, cmd = vb.focusedModel.Update(msg)
+		return vb, cmd
+	}
+
+	// All other messages go to each model
+	var cc utils.CmdCollector
+	vb.visibleModel = cc.Collect(vb.visibleModel.Update(msg))
+	vb.focusedModel = cc.Collect(vb.focusedModel.Update(msg))
+	for i, c := range vb.otherModels {
+		vb.otherModels[i] = cc.Collect(c.Update(msg))
+	}
+	return vb, cc.Cmd()
+}
+
+func (vb ZStack) View() string {
+	return vb.visibleModel.View()
+}
+
+func (vb ZStack) Resize(w, h int) ResizingModel {
+	vb.visibleModel = Resize(vb.visibleModel, w, h)
+	vb.focusedModel = Resize(vb.focusedModel, w, h)
+	for i := range vb.otherModels {
+		vb.otherModels[i] = Resize(vb.otherModels[i], w, h)
+	}
+	return vb
+}

--- a/internal/dynamo-browse/ui/teamodels/utils/minmax.go
+++ b/internal/dynamo-browse/ui/teamodels/utils/minmax.go
@@ -6,3 +6,17 @@ func Max(x, y int) int {
 	}
 	return y
 }
+
+func Cycle(n int, by int, max int) int {
+	by = by % max
+	if by > 0 {
+		return (n + by) % max
+	} else if by < 0 {
+		wn := n + by
+		if wn < 0 {
+			return max + wn
+		}
+		return wn
+	}
+	return n
+}


### PR DESCRIPTION
This allows the user to cycle between 5 different sizes by pressing the `w` key.  Pressing `W` will cycle through the sizes in reverse order.