### PR TITLE
issue-28: added default limit as a setting

### DIFF
--- a/cmd/dynamo-browse/main.go
+++ b/cmd/dynamo-browse/main.go
@@ -34,6 +34,7 @@ func main() {
 	var flagLocal = flag.String("local", "", "local endpoint")
 	var flagDebug = flag.String("debug", "", "file to log debug messages")
 	var flagRO = flag.Bool("ro", false, "enable readonly mode")
+	var flagDefaultLimit = flag.Int("default-limit", 0, "default limit for queries and scans")
 	var flagWorkspace = flag.String("w", "", "workspace file")
 	flag.Parse()
 
@@ -80,6 +81,11 @@ func main() {
 	if *flagRO {
 		if err := settingStore.SetReadOnly(*flagRO); err != nil {
 			cli.Fatalf("unable to set read-only mode: %v", err)
+		}
+	}
+	if *flagDefaultLimit > 0 {
+		if err := settingStore.SetDefaultLimit(*flagDefaultLimit); err != nil {
+			cli.Fatalf("unable to set default limit: %v", err)
 		}
 	}
 

--- a/internal/dynamo-browse/controllers/iface.go
+++ b/internal/dynamo-browse/controllers/iface.go
@@ -16,4 +16,6 @@ type TableReadService interface {
 type SettingsProvider interface {
 	IsReadOnly() (bool, error)
 	SetReadOnly(ro bool) error
+	DefaultLimit() (limit int)
+	SetDefaultLimit(limit int) error
 }

--- a/internal/dynamo-browse/controllers/settings.go
+++ b/internal/dynamo-browse/controllers/settings.go
@@ -1,10 +1,12 @@
 package controllers
 
 import (
+	"fmt"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/lmika/audax/internal/common/ui/events"
 	"github.com/pkg/errors"
 	"log"
+	"strconv"
 )
 
 type SettingsController struct {
@@ -35,7 +37,21 @@ func (sc *SettingsController) SetSetting(name string, value string) tea.Msg {
 			Message: "In read-write mode",
 			Next:    SettingsUpdated{},
 		}
+	case "default-limit":
+		newLimit, err := strconv.Atoi(value)
+		if err != nil {
+			return errors.Wrapf(err, "bad value: %v", value)
+		}
+
+		if err := sc.settings.SetDefaultLimit(newLimit); err != nil {
+			return events.Error(err)
+		}
+		return events.WrappedStatusMsg{
+			Message: events.StatusMsg(fmt.Sprintf("Default query limit now %v", newLimit)),
+			Next:    SettingsUpdated{},
+		}
 	}
+
 	return events.Error(errors.Errorf("unrecognised setting: %v", name))
 }
 

--- a/internal/dynamo-browse/controllers/settings_test.go
+++ b/internal/dynamo-browse/controllers/settings_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestSettingsController_SetSetting(t *testing.T) {
 	t.Run("read-only setting", func(t *testing.T) {
-		srv := newService(t, false)
+		srv := newService(t, serviceConfig{})
 
 		msg := invokeCommand(t, srv.settingsController.SetSetting("ro", ""))
 
@@ -19,12 +19,21 @@ func TestSettingsController_SetSetting(t *testing.T) {
 	})
 
 	t.Run("read-write setting", func(t *testing.T) {
-		srv := newService(t, true)
+		srv := newService(t, serviceConfig{isReadOnly: true})
 
 		msg := invokeCommand(t, srv.settingsController.SetSetting("rw", ""))
 
 		assert.False(t, srv.settingsController.IsReadOnly())
 		assert.IsType(t, events.WrappedStatusMsg{}, msg)
 		assert.IsType(t, controllers.SettingsUpdated{}, msg.(events.WrappedStatusMsg).Next)
+	})
+
+	t.Run("set default limit", func(t *testing.T) {
+		srv := newService(t, serviceConfig{})
+
+		assert.Equal(t, 1000, srv.settingProvider.DefaultLimit())
+		invokeCommand(t, srv.settingsController.SetSetting("default-limit", "20"))
+
+		assert.Equal(t, 20, srv.settingProvider.DefaultLimit())
 	})
 }

--- a/internal/dynamo-browse/providers/settingstore/settingstore.go
+++ b/internal/dynamo-browse/providers/settingstore/settingstore.go
@@ -3,12 +3,17 @@ package settingstore
 import (
 	"github.com/asdine/storm"
 	"github.com/lmika/audax/internal/common/workspaces"
+	"github.com/pkg/errors"
+	"log"
 )
 
 const settingBucket = "Settings"
 
 const (
-	keyTableReadOnly = "table_ro"
+	keyTableReadOnly     = "ro"
+	keyTableDefaultLimit = "default_limit"
+
+	defaultsDefaultLimit = 1000
 )
 
 type SettingStore struct {
@@ -22,10 +27,30 @@ func New(ws *workspaces.Workspace) *SettingStore {
 }
 
 func (c *SettingStore) IsReadOnly() (b bool, err error) {
-	err = c.ws.Get(settingBucket, keyTableReadOnly, &b)
+	if err := c.ws.Get(settingBucket, keyTableReadOnly, &b); err != nil {
+		if errors.Is(err, storm.ErrNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
 	return b, err
 }
 
 func (c *SettingStore) SetReadOnly(ro bool) error {
 	return c.ws.Set(settingBucket, keyTableReadOnly, ro)
+}
+
+func (c *SettingStore) DefaultLimit() (limit int) {
+	err := c.ws.Get(settingBucket, keyTableDefaultLimit, &limit)
+	if err != nil {
+		if !errors.Is(err, storm.ErrNotFound) {
+			log.Printf("warn: cannot get default limit from workspace, using default value: %v", err)
+		}
+		return defaultsDefaultLimit
+	}
+	return limit
+}
+
+func (c *SettingStore) SetDefaultLimit(limit int) error {
+	return errors.Wrapf(c.ws.Set(settingBucket, keyTableDefaultLimit, &limit), "cannot set default limit to %v", limit)
 }

--- a/internal/dynamo-browse/services/tables/iface.go
+++ b/internal/dynamo-browse/services/tables/iface.go
@@ -18,6 +18,7 @@ type TableProvider interface {
 	PutItems(ctx context.Context, name string, items []models.Item) error
 }
 
-type ROProvider interface {
+type ConfigProvider interface {
 	IsReadOnly() (bool, error)
+	DefaultLimit() int
 }

--- a/internal/dynamo-browse/services/tables/service_test.go
+++ b/internal/dynamo-browse/services/tables/service_test.go
@@ -19,7 +19,7 @@ func TestService_Describe(t *testing.T) {
 	t.Run("return details of the table", func(t *testing.T) {
 		ctx := context.Background()
 
-		service := tables.NewService(provider, mockedReadOnlyProvider{readOnly: false})
+		service := tables.NewService(provider, mockedConfigProvider{readOnly: false})
 		ti, err := service.Describe(ctx, tableName)
 		assert.NoError(t, err)
 
@@ -40,16 +40,29 @@ func TestService_Scan(t *testing.T) {
 	t.Run("return all columns and fields in sorted order", func(t *testing.T) {
 		ctx := context.Background()
 
-		service := tables.NewService(provider, mockedReadOnlyProvider{readOnly: false})
+		service := tables.NewService(provider, mockedConfigProvider{readOnly: false})
 		ti, err := service.Describe(ctx, tableName)
 		assert.NoError(t, err)
 
 		rs, err := service.Scan(ctx, ti)
 		assert.NoError(t, err)
+		assert.Len(t, rs.Items(), 3)
 
 		// Hash first, then range, then columns in alphabetic order
 		assert.Equal(t, rs.TableInfo, ti)
 		assert.Equal(t, rs.Columns(), []string{"pk", "sk", "alpha", "beta", "gamma"})
+	})
+
+	t.Run("should honour default limits", func(t *testing.T) {
+		ctx := context.Background()
+
+		service := tables.NewService(provider, mockedConfigProvider{readOnly: false, defaultLimit: 2})
+		ti, err := service.Describe(ctx, tableName)
+		assert.NoError(t, err)
+
+		rs, err := service.Scan(ctx, ti)
+		assert.NoError(t, err)
+		assert.Len(t, rs.Items(), 2)
 	})
 }
 
@@ -78,10 +91,18 @@ var testData = []testdynamo.TestData{
 	},
 }
 
-type mockedReadOnlyProvider struct {
-	readOnly bool
+type mockedConfigProvider struct {
+	readOnly     bool
+	defaultLimit int
 }
 
-func (m mockedReadOnlyProvider) IsReadOnly() (bool, error) {
+func (m mockedConfigProvider) IsReadOnly() (bool, error) {
 	return m.readOnly, nil
+}
+
+func (m mockedConfigProvider) DefaultLimit() int {
+	if m.defaultLimit == 0 {
+		return 1000
+	}
+	return m.defaultLimit
 }

--- a/test/cmd/load-test-table/main.go
+++ b/test/cmd/load-test-table/main.go
@@ -106,6 +106,10 @@ func createTable(ctx context.Context, dynamoClient *dynamodb.Client, tableName s
 
 type notROService struct{}
 
+func (n notROService) DefaultLimit() int {
+	return 1000
+}
+
 func (n notROService) IsReadOnly() (bool, error) {
 	return false, nil
 }


### PR DESCRIPTION
- Added default query/scan result limits as a setting with the name `default-limit`
- Added the flag `default-limit`