### PR TITLE
Issue 23: Added progress indicators and cancellation

### DIFF
--- a/cmd/dynamo-browse/main.go
+++ b/cmd/dynamo-browse/main.go
@@ -98,7 +98,7 @@ func main() {
 	jobsService := jobs.NewService(eventBus)
 
 	state := controllers.NewState()
-	jobsController := controllers.NewJobsController(jobsService, eventBus)
+	jobsController := controllers.NewJobsController(jobsService, eventBus, false)
 	tableReadController := controllers.NewTableReadController(state, tableService, workspaceService, itemRendererService, jobsController, eventBus, *flagTable)
 	tableWriteController := controllers.NewTableWriteController(state, tableService, jobsController, tableReadController, settingStore)
 	columnsController := controllers.NewColumnsController(eventBus)

--- a/cmd/dynamo-browse/main.go
+++ b/cmd/dynamo-browse/main.go
@@ -100,7 +100,7 @@ func main() {
 	state := controllers.NewState()
 	jobsController := controllers.NewJobsController(jobsService, eventBus)
 	tableReadController := controllers.NewTableReadController(state, tableService, workspaceService, itemRendererService, jobsController, eventBus, *flagTable)
-	tableWriteController := controllers.NewTableWriteController(state, tableService, tableReadController, settingStore)
+	tableWriteController := controllers.NewTableWriteController(state, tableService, jobsController, tableReadController, settingStore)
 	columnsController := controllers.NewColumnsController(eventBus)
 	exportController := controllers.NewExportController(state, columnsController)
 	settingsController := controllers.NewSettingsController(settingStore)

--- a/internal/common/ui/commandctrl/commandctrl.go
+++ b/internal/common/ui/commandctrl/commandctrl.go
@@ -57,14 +57,20 @@ func (c *CommandController) execute(ctx ExecContext, commandInput string) tea.Ms
 	return command(ctx, tokens[1:])
 }
 
-func (c *CommandController) Alias(commandName string) Command {
+func (c *CommandController) Alias(commandName string, aliasArgs []string) Command {
 	return func(ctx ExecContext, args []string) tea.Msg {
 		command := c.lookupCommand(commandName)
 		if command == nil {
 			return events.Error(errors.New("no such command: " + commandName))
 		}
 
-		return command(ctx, args)
+		var allArgs []string
+		if len(aliasArgs) > 0 {
+			allArgs = append(append([]string{}, aliasArgs...), args...)
+		} else {
+			allArgs = args
+		}
+		return command(ctx, allArgs)
 	}
 }
 

--- a/internal/common/ui/events/commands.go
+++ b/internal/common/ui/events/commands.go
@@ -29,7 +29,13 @@ func PromptForInput(prompt string, onDone func(value string) tea.Msg) tea.Msg {
 	}
 }
 
-func Confirm(prompt string, onYes func() tea.Msg) tea.Msg {
+func Confirm(prompt string, onResult func(yes bool) tea.Msg) tea.Msg {
+	return PromptForInput(prompt, func(value string) tea.Msg {
+		return onResult(value == "y")
+	})
+}
+
+func ConfirmYes(prompt string, onYes func() tea.Msg) tea.Msg {
 	return PromptForInput(prompt, func(value string) tea.Msg {
 		if value == "y" {
 			return onYes()

--- a/internal/common/ui/events/jobs.go
+++ b/internal/common/ui/events/jobs.go
@@ -1,0 +1,6 @@
+package events
+
+type ForegroundJobUpdate struct {
+	JobRunning bool
+	JobStatus  string
+}

--- a/internal/dynamo-browse/controllers/jobbuilder.go
+++ b/internal/dynamo-browse/controllers/jobbuilder.go
@@ -65,10 +65,14 @@ func (jb JobBuilder[T]) doSubmit() tea.Msg {
 		msg := jb.executeJob(ctx)
 
 		jb.jc.msgSender(msg)
-		jb.jc.msgSender(events.ForegroundJobUpdate{
-			JobRunning: false,
-			JobStatus:  "",
-		})
+
+		if _, isForegroundJobUpdate := msg.(events.ForegroundJobUpdate); !isForegroundJobUpdate {
+			// Likely another job was scheduled so don't indicate that no jobs are running.
+			jb.jc.msgSender(events.ForegroundJobUpdate{
+				JobRunning: false,
+				JobStatus:  "",
+			})
+		}
 	}, func(msg string) {
 		jb.jc.msgSender(events.ForegroundJobUpdate{
 			JobRunning: true,

--- a/internal/dynamo-browse/controllers/jobbuilder.go
+++ b/internal/dynamo-browse/controllers/jobbuilder.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/lmika/audax/internal/common/ui/events"
-	"time"
 )
 
 func NewJob[T any](jc *JobsController, description string, job func(ctx context.Context) (T, error)) JobBuilder[T] {
@@ -62,35 +61,20 @@ func (jb JobBuilder[T]) executeJob(ctx context.Context) tea.Msg {
 }
 
 func (jb JobBuilder[T]) doSubmit() tea.Msg {
-	jobFinished := make(chan tea.Msg)
-
 	jb.jc.service.SubmitForegroundJob(func(ctx context.Context) {
 		msg := jb.executeJob(ctx)
 
-		select {
-		case jobFinished <- msg:
-			// Waited for the job to finish, so get it now
-		default:
-			// Not waiting for job to finish, so
-			jb.jc.msgSender(msg)
-			jb.jc.msgSender(events.ForegroundJobUpdate{
-				JobRunning: false,
-				JobStatus:  "",
-			})
-		}
+		jb.jc.msgSender(msg)
+		jb.jc.msgSender(events.ForegroundJobUpdate{
+			JobRunning: false,
+			JobStatus:  "",
+		})
 	}, func(msg string) {
 		jb.jc.msgSender(events.ForegroundJobUpdate{
 			JobRunning: true,
 			JobStatus:  jb.description + " " + msg,
 		})
 	})
-
-	// Wait 700 msecs to see if the job finishes in time, otherwise indicate that a job is running
-	select {
-	case msg := <-jobFinished:
-		return msg
-	case <-time.After(70 * time.Millisecond):
-	}
 
 	return events.ForegroundJobUpdate{
 		JobRunning: true,

--- a/internal/dynamo-browse/controllers/jobbuilder.go
+++ b/internal/dynamo-browse/controllers/jobbuilder.go
@@ -1,0 +1,75 @@
+package controllers
+
+import (
+	"context"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/lmika/audax/internal/common/ui/events"
+	"time"
+)
+
+func NewJob[T any](jc *JobsController, description string, job func(ctx context.Context) (T, error)) JobBuilder[T] {
+	return JobBuilder[T]{jc: jc, description: description, job: job}
+}
+
+type JobBuilder[T any] struct {
+	jc          *JobsController
+	description string
+	job         func(ctx context.Context) (T, error)
+	onDone      func(res T) tea.Msg
+	onErr       func(err error) tea.Msg
+}
+
+func (jb JobBuilder[T]) OnDone(fn func(res T) tea.Msg) JobBuilder[T] {
+	newJb := jb
+	newJb.onDone = fn
+	return newJb
+}
+
+func (jb JobBuilder[T]) OnErr(fn func(err error) tea.Msg) JobBuilder[T] {
+	newJb := jb
+	newJb.onErr = fn
+	return newJb
+}
+
+func (jb JobBuilder[T]) Submit() tea.Msg {
+	jobFinished := make(chan tea.Msg)
+
+	jb.jc.service.SubmitForegroundJob(func(ctx context.Context) {
+		res, err := jb.job(ctx)
+
+		var msg tea.Msg
+		if err == nil {
+			msg = jb.onDone(res)
+		} else {
+			if jb.onErr != nil {
+				msg = jb.onErr(err)
+			} else {
+				msg = events.Error(err)
+			}
+		}
+
+		select {
+		case jobFinished <- msg:
+			// Waited for the job to finish, so get it now
+		default:
+			// Not waiting for job to finish, so
+			jb.jc.msgSender(msg)
+			jb.jc.msgSender(events.ForegroundJobUpdate{
+				JobRunning: false,
+				JobStatus:  "",
+			})
+		}
+	})
+
+	// Wait 700 msecs to see if the job finishes in time, otherwise indicate that a job is running
+	select {
+	case msg := <-jobFinished:
+		return msg
+	case <-time.After(70 * time.Millisecond):
+	}
+
+	return events.ForegroundJobUpdate{
+		JobRunning: true,
+		JobStatus:  jb.description,
+	}
+}

--- a/internal/dynamo-browse/controllers/jobs.go
+++ b/internal/dynamo-browse/controllers/jobs.go
@@ -10,11 +10,13 @@ import (
 type JobsController struct {
 	service   *jobs.Services
 	msgSender func(msg tea.Msg)
+	immediate bool
 }
 
-func NewJobsController(service *jobs.Services, bus *bus.Bus) *JobsController {
+func NewJobsController(service *jobs.Services, bus *bus.Bus, immediate bool) *JobsController {
 	jc := &JobsController{
-		service: service,
+		service:   service,
+		immediate: immediate,
 	}
 
 	return jc

--- a/internal/dynamo-browse/controllers/jobs.go
+++ b/internal/dynamo-browse/controllers/jobs.go
@@ -1,0 +1,60 @@
+package controllers
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/lmika/audax/internal/common/ui/events"
+	"github.com/lmika/audax/internal/dynamo-browse/services/jobs"
+	bus "github.com/lmika/events"
+)
+
+type JobsController struct {
+	service   *jobs.Services
+	msgSender func(msg tea.Msg)
+}
+
+func NewJobsController(service *jobs.Services, bus *bus.Bus) *JobsController {
+	jc := &JobsController{
+		service: service,
+	}
+
+	bus.On(jobs.JobEventForegroundDone, jc.onJobDone)
+	return jc
+}
+
+func (js *JobsController) SetMessageSender(msgSender func(msg tea.Msg)) {
+	js.msgSender = msgSender
+}
+
+func (js *JobsController) SubmitJob(job jobs.Job) tea.Msg {
+	js.service.SubmitForegroundJob(job)
+	return events.ForegroundJobUpdate{
+		JobRunning: true,
+		JobStatus:  "Job started… press Ctrl+C to stop",
+	}
+}
+
+func (jc *JobsController) onJobDone(eventData jobs.JobDoneEvent) {
+	if err := eventData.Err; err != nil {
+		jc.msgSender(events.ForegroundJobUpdate{
+			JobRunning: false,
+			JobStatus:  "Err: " + err.Error(),
+		})
+		return
+	}
+
+	jc.msgSender(events.ForegroundJobUpdate{
+		JobRunning: false,
+		JobStatus:  "",
+	})
+}
+
+func (js *JobsController) CancelRunningJob() tea.Msg {
+	hasCancelled := js.service.CancelForegroundJob()
+	if !hasCancelled {
+		return events.ForegroundJobUpdate{
+			JobRunning: true,
+			JobStatus:  "Cancelling running job…",
+		}
+	}
+	return events.StatusMsg("No running job")
+}

--- a/internal/dynamo-browse/controllers/jobs.go
+++ b/internal/dynamo-browse/controllers/jobs.go
@@ -26,7 +26,7 @@ func (js *JobsController) SetMessageSender(msgSender func(msg tea.Msg)) {
 	js.msgSender = msgSender
 }
 
-func (js *JobsController) CancelRunningJob() tea.Msg {
+func (js *JobsController) CancelRunningJob(ifNoJobsRunning func() tea.Msg) tea.Msg {
 	hasCancelled := js.service.CancelForegroundJob()
 	if hasCancelled {
 		return events.ForegroundJobUpdate{
@@ -34,5 +34,5 @@ func (js *JobsController) CancelRunningJob() tea.Msg {
 			JobStatus:  "Cancelling running job…",
 		}
 	}
-	return events.StatusMsg("No running job")
+	return ifNoJobsRunning()
 }

--- a/internal/dynamo-browse/controllers/keybinding.go
+++ b/internal/dynamo-browse/controllers/keybinding.go
@@ -27,7 +27,7 @@ func (kb *KeyBindingController) Rebind(bindingName string, newKey string, force 
 	var keyAlreadyBoundErr keybindings.KeyAlreadyBoundError
 	if errors.As(err, &keyAlreadyBoundErr) {
 		promptMsg := fmt.Sprintf("Key '%v' already bound to '%v'.  Continue? ", keyAlreadyBoundErr.Key, keyAlreadyBoundErr.ExistingBindingName)
-		return events.Confirm(promptMsg, func() tea.Msg {
+		return events.ConfirmYes(promptMsg, func() tea.Msg {
 			err := kb.service.Rebind(bindingName, newKey, true)
 			if err != nil {
 				return events.Error(err)

--- a/internal/dynamo-browse/controllers/tableread.go
+++ b/internal/dynamo-browse/controllers/tableread.go
@@ -117,6 +117,7 @@ func (c *TableReadController) ScanTable(name string) tea.Msg {
 		if err != nil {
 			return nil, err
 		}
+
 		resultSet = c.tableService.Filter(resultSet, c.state.Filter())
 
 		return resultSet, nil
@@ -247,15 +248,6 @@ func (c *TableReadController) Mark(op MarkOp) tea.Msg {
 			case MarkOpToggle:
 				resultSet.SetMark(i, !resultSet.Marked(i))
 			}
-		}
-	})
-	return ResultSetUpdated{}
-}
-
-func (c *TableReadController) Unmark() tea.Msg {
-	c.state.withResultSet(func(resultSet *models.ResultSet) {
-		for i := range resultSet.Items() {
-			resultSet.SetMark(i, false)
 		}
 	})
 	return ResultSetUpdated{}

--- a/internal/dynamo-browse/controllers/tablewrite.go
+++ b/internal/dynamo-browse/controllers/tablewrite.go
@@ -239,31 +239,6 @@ func (twc *TableWriteController) DeleteAttribute(idx int, key string) tea.Msg {
 	return ResultSetUpdated{}
 }
 
-//func (twc *TableWriteController) PutItem(idx int) tea.Msg {
-//	if err := twc.assertReadWrite(); err != nil {
-//		return events.Error(err)
-//	}
-//
-//	resultSet := twc.state.ResultSet()
-//	if !resultSet.IsDirty(idx) {
-//		return events.Error(errors.New("item is not dirty"))
-//	}
-//
-//	return events.PromptForInputMsg{
-//		Prompt: "put item? ",
-//		OnDone: func(value string) tea.Msg {
-//			if value != "y" {
-//				return nil
-//			}
-//
-//			if err := twc.tableService.PutItemAt(context.Background(), resultSet, idx); err != nil {
-//				return events.Error(err)
-//			}
-//			return ResultSetUpdated{}
-//		},
-//	}
-//}
-
 func (twc *TableWriteController) PutItems() tea.Msg {
 	if err := twc.assertReadWrite(); err != nil {
 		return events.Error(err)

--- a/internal/dynamo-browse/controllers/tablewrite_test.go
+++ b/internal/dynamo-browse/controllers/tablewrite_test.go
@@ -49,7 +49,7 @@ func TestTableWriteController_NewItem(t *testing.T) {
 		// Prompt for keys
 		invokeCommandExpectingError(t, srv.writeController.NewItem())
 
-		// Confirm no changes
+		// ConfirmYes no changes
 		invokeCommand(t, srv.readController.Rescan())
 
 		newResultSet := srv.state.ResultSet()

--- a/internal/dynamo-browse/controllers/tablewrite_test.go
+++ b/internal/dynamo-browse/controllers/tablewrite_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lmika/audax/internal/dynamo-browse/providers/settingstore"
 	"github.com/lmika/audax/internal/dynamo-browse/providers/workspacestore"
 	"github.com/lmika/audax/internal/dynamo-browse/services/itemrenderer"
+	"github.com/lmika/audax/internal/dynamo-browse/services/jobs"
 	"github.com/lmika/audax/internal/dynamo-browse/services/tables"
 	workspaces_service "github.com/lmika/audax/internal/dynamo-browse/services/workspaces"
 	"github.com/lmika/audax/test/testdynamo"
@@ -240,7 +241,7 @@ func TestTableWriteController_PutItem(t *testing.T) {
 
 		// Modify the item and put it
 		invokeCommandWithPrompt(t, srv.writeController.SetAttributeValue(0, models.StringItemType, "alpha"), "a new value")
-		invokeCommandWithPrompt(t, srv.writeController.PutItem(0), "y")
+		invokeCommandWithPrompt(t, srv.writeController.PutItems(), "y")
 
 		// Rescan the table
 		invokeCommand(t, srv.readController.Rescan())
@@ -260,7 +261,7 @@ func TestTableWriteController_PutItem(t *testing.T) {
 
 		// Modify the item but do not put it
 		invokeCommandWithPrompt(t, srv.writeController.SetAttributeValue(0, models.StringItemType, "alpha"), "a new value")
-		invokeCommandWithPrompt(t, srv.writeController.PutItem(0), "n")
+		invokeCommandWithPrompt(t, srv.writeController.PutItems(), "n")
 
 		current, _ := srv.state.ResultSet().Items()[0].AttributeValueAsString("alpha")
 		assert.Equal(t, "a new value", current)
@@ -282,7 +283,7 @@ func TestTableWriteController_PutItem(t *testing.T) {
 		assert.Equal(t, "This is some value", before)
 		assert.False(t, srv.state.ResultSet().IsDirty(0))
 
-		invokeCommandExpectingError(t, srv.writeController.PutItem(0))
+		invokeCommand(t, srv.writeController.PutItems())
 	})
 
 	t.Run("should not put the selected item if in read-only mode", func(t *testing.T) {
@@ -296,7 +297,7 @@ func TestTableWriteController_PutItem(t *testing.T) {
 
 		// Modify the item but do not put it
 		invokeCommandWithPrompt(t, srv.writeController.SetAttributeValue(0, models.StringItemType, "alpha"), "a new value")
-		invokeCommandExpectingError(t, srv.writeController.PutItem(0))
+		invokeCommandExpectingError(t, srv.writeController.PutItems())
 
 		current, _ := srv.state.ResultSet().Items()[0].AttributeValueAsString("alpha")
 		assert.Equal(t, "a new value", current)
@@ -596,8 +597,9 @@ func newService(t *testing.T, cfg serviceConfig) *services {
 	eventBus := bus.New()
 
 	state := controllers.NewState()
-	readController := controllers.NewTableReadController(state, service, workspaceService, itemRendererService, eventBus, cfg.tableName)
-	writeController := controllers.NewTableWriteController(state, service, readController, settingStore)
+	jobsController := controllers.NewJobsController(jobs.NewService(eventBus), eventBus, true)
+	readController := controllers.NewTableReadController(state, service, workspaceService, itemRendererService, jobsController, eventBus, cfg.tableName)
+	writeController := controllers.NewTableWriteController(state, service, jobsController, readController, settingStore)
 	settingsController := controllers.NewSettingsController(settingStore)
 	columnsController := controllers.NewColumnsController(eventBus)
 	exportController := controllers.NewExportController(state, columnsController)

--- a/internal/dynamo-browse/models/errors.go
+++ b/internal/dynamo-browse/models/errors.go
@@ -1,5 +1,23 @@
 package models
 
-import "github.com/pkg/errors"
+import (
+	"github.com/pkg/errors"
+)
 
 var ErrReadOnly = errors.New("in read-only mode")
+
+type PartialResultsError struct {
+	err error
+}
+
+func NewPartialResultsError(err error) PartialResultsError {
+	return PartialResultsError{err: err}
+}
+
+func (pr PartialResultsError) Error() string {
+	return "partial results received"
+}
+
+func (pr PartialResultsError) Unwrap() error {
+	return pr.err
+}

--- a/internal/dynamo-browse/providers/dynamo/provider.go
+++ b/internal/dynamo-browse/providers/dynamo/provider.go
@@ -11,7 +11,6 @@ import (
 	"github.com/lmika/audax/internal/dynamo-browse/models"
 	"github.com/lmika/audax/internal/dynamo-browse/services/jobs"
 	"github.com/pkg/errors"
-	"log"
 	"time"
 )
 
@@ -88,7 +87,6 @@ func (p *Provider) batchPutItems(ctx context.Context, name string, items []model
 			return types.WriteRequest{PutRequest: &types.PutRequest{Item: item}}
 		})
 
-		log.Printf("Page")
 		_, err := p.client.BatchWriteItem(ctx, &dynamodb.BatchWriteItemInput{
 			RequestItems: map[string][]types.WriteRequest{
 				name: writeRequests,

--- a/internal/dynamo-browse/providers/dynamo/provider.go
+++ b/internal/dynamo-browse/providers/dynamo/provider.go
@@ -127,6 +127,9 @@ outer:
 	for paginator.HasMorePages() {
 		res, err := paginator.NextPage(ctx)
 		if err != nil {
+			if ctx.Err() != nil {
+				return items, models.NewPartialResultsError(ctx.Err())
+			}
 			return nil, errors.Wrapf(err, "cannot execute scan on table %v", tableName)
 		}
 
@@ -168,6 +171,9 @@ outer:
 	for paginator.HasMorePages() {
 		res, err := paginator.NextPage(ctx)
 		if err != nil {
+			if ctx.Err() != nil {
+				return items, models.NewPartialResultsError(ctx.Err())
+			}
 			return nil, errors.Wrapf(err, "cannot execute query on table %v", tableName)
 		}
 

--- a/internal/dynamo-browse/services/jobs/ctx.go
+++ b/internal/dynamo-browse/services/jobs/ctx.go
@@ -1,0 +1,25 @@
+package jobs
+
+import (
+	"context"
+)
+
+type jobUpdaterKeyType struct{}
+
+var jobUpdaterKey = jobUpdaterKeyType{}
+
+type jobUpdaterValue struct {
+	msgUpdate chan string
+}
+
+func PostUpdate(ctx context.Context, msg string) {
+	val, hasVal := ctx.Value(jobUpdaterKey).(*jobUpdaterValue)
+	if !hasVal {
+		return
+	}
+
+	select {
+	case val.msgUpdate <- msg:
+	default:
+	}
+}

--- a/internal/dynamo-browse/services/jobs/events.go
+++ b/internal/dynamo-browse/services/jobs/events.go
@@ -1,0 +1,9 @@
+package jobs
+
+const (
+	JobEventForegroundDone = "job_foreground_done"
+)
+
+type JobDoneEvent struct {
+	Err error
+}

--- a/internal/dynamo-browse/services/jobs/jobs.go
+++ b/internal/dynamo-browse/services/jobs/jobs.go
@@ -1,0 +1,68 @@
+package jobs
+
+import (
+	"context"
+	bus "github.com/lmika/events"
+	"sync"
+)
+
+type Job func(ctx context.Context) error
+
+type jobInfo struct {
+	ctx      context.Context
+	cancelFn func()
+}
+
+type Services struct {
+	bus *bus.Bus
+
+	mutex         *sync.Mutex
+	foregroundJob *jobInfo
+}
+
+func NewService(bus *bus.Bus) *Services {
+	return &Services{
+		bus:   bus,
+		mutex: new(sync.Mutex),
+	}
+}
+
+// SubmitForegroundJob starts a foreground job.
+func (jc *Services) SubmitForegroundJob(job Job) {
+	// TODO: if there's already a foreground job, then return error
+
+	ctx, cancelFn := context.WithCancel(context.Background())
+	newJobInfo := &jobInfo{
+		ctx:      ctx,
+		cancelFn: cancelFn,
+	}
+	// TODO: needs to be protected by the mutex
+	jc.foregroundJob = newJobInfo
+
+	go func() {
+		defer cancelFn()
+
+		err := job(newJobInfo.ctx)
+		jc.bus.Fire(JobEventForegroundDone, JobDoneEvent{Err: err})
+
+		// TODO: needs to be protected by the mutex
+		jc.foregroundJob = nil
+	}()
+}
+
+func (jc *Services) CancelForegroundJob() bool {
+	// TODO: needs to be protected by the mutex
+	if jc.foregroundJob != nil {
+		// A nil cancel for a non-nil foreground job indicates that the cancellation function
+		// has been called and the job is in the process of stopping
+		if jc.foregroundJob.cancelFn == nil {
+			return false
+		}
+
+		jc.foregroundJob.cancelFn()
+		jc.foregroundJob.cancelFn = nil
+		return true
+	}
+
+	return false
+}

--- a/internal/dynamo-browse/services/jobs/jobs.go
+++ b/internal/dynamo-browse/services/jobs/jobs.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 )
 
-type Job func(ctx context.Context) error
+type Job func(ctx context.Context)
 
 type jobInfo struct {
 	ctx      context.Context
@@ -42,8 +42,8 @@ func (jc *Services) SubmitForegroundJob(job Job) {
 	go func() {
 		defer cancelFn()
 
-		err := job(newJobInfo.ctx)
-		jc.bus.Fire(JobEventForegroundDone, JobDoneEvent{Err: err})
+		job(newJobInfo.ctx)
+		//jc.bus.Fire(JobEventForegroundDone, JobDoneEvent{Err: err})
 
 		// TODO: needs to be protected by the mutex
 		jc.foregroundJob = nil

--- a/internal/dynamo-browse/services/tables/service.go
+++ b/internal/dynamo-browse/services/tables/service.go
@@ -160,6 +160,10 @@ func (s *Service) assertReadWrite() error {
 
 // TODO: move into a new service
 func (s *Service) Filter(resultSet *models.ResultSet, filter string) *models.ResultSet {
+	if resultSet == nil {
+		return nil
+	}
+
 	for i, item := range resultSet.Items() {
 		if filter == "" {
 			resultSet.SetHidden(i, false)

--- a/internal/dynamo-browse/services/tables/service.go
+++ b/internal/dynamo-browse/services/tables/service.go
@@ -63,7 +63,7 @@ func (s *Service) doScan(ctx context.Context, tableInfo *models.TableInfo, expr 
 		results, err = s.provider.ScanItems(ctx, tableInfo.Name, filterExpr, limit)
 	}
 
-	if err != nil {
+	if err != nil && len(results) == 0 {
 		return nil, errors.Wrapf(err, "unable to scan table %v", tableInfo.Name)
 	}
 
@@ -76,7 +76,7 @@ func (s *Service) doScan(ctx context.Context, tableInfo *models.TableInfo, expr 
 	resultSet.SetItems(results)
 	resultSet.RefreshColumns()
 
-	return resultSet, nil
+	return resultSet, err
 }
 
 func (s *Service) Put(ctx context.Context, tableInfo *models.TableInfo, item models.Item) error {

--- a/internal/dynamo-browse/ui/keybindings/defaults.go
+++ b/internal/dynamo-browse/ui/keybindings/defaults.go
@@ -35,7 +35,8 @@ func Default() *KeyBindings {
 			CycleLayoutBackwards: key.NewBinding(key.WithKeys("W"), key.WithHelp("W", "cycle layout backward")),
 			PromptForCommand:     key.NewBinding(key.WithKeys(":"), key.WithHelp(":", "prompt for command")),
 			ShowColumnOverlay:    key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "show column overlay")),
-			Quit:                 key.NewBinding(key.WithKeys("ctrl+c", "esc"), key.WithHelp("ctrl+c/esc", "quit")),
+			CancelRunningJob:     key.NewBinding(key.WithKeys("ctrl+c"), key.WithHelp("ctrl+c", "cancel running job or quit")),
+			Quit:                 key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "quit")),
 		},
 	}
 }

--- a/internal/dynamo-browse/ui/keybindings/keybindings.go
+++ b/internal/dynamo-browse/ui/keybindings/keybindings.go
@@ -42,5 +42,6 @@ type ViewKeyBindings struct {
 	CycleLayoutBackwards key.Binding `keymap:"cycle-layout-backwards"`
 	PromptForCommand     key.Binding `keymap:"prompt-for-command"`
 	ShowColumnOverlay    key.Binding `keymap:"show-column-overlay"`
+	CancelRunningJob     key.Binding `keymap:"cancel-running-job"`
 	Quit                 key.Binding `keymap:"quit"`
 }

--- a/internal/dynamo-browse/ui/model.go
+++ b/internal/dynamo-browse/ui/model.go
@@ -115,7 +115,6 @@ func NewModel(
 
 				return rc.Mark(markOp)
 			},
-			"unmark": commandctrl.NoArgCommand(rc.Unmark),
 			"delete": commandctrl.NoArgCommand(wc.DeleteMarked),
 
 			// TEMP
@@ -185,10 +184,11 @@ func NewModel(
 			},
 
 			// Aliases
-			"sa": cc.Alias("set-attr"),
-			"da": cc.Alias("del-attr"),
-			"w":  cc.Alias("put"),
-			"q":  cc.Alias("quit"),
+			"unmark": cc.Alias("mark", []string{"none"}),
+			"sa":     cc.Alias("set-attr", nil),
+			"da":     cc.Alias("del-attr", nil),
+			"w":      cc.Alias("put", nil),
+			"q":      cc.Alias("quit", nil),
 		},
 	})
 

--- a/internal/dynamo-browse/ui/model.go
+++ b/internal/dynamo-browse/ui/model.go
@@ -144,11 +144,6 @@ func NewModel(
 				return wc.NoisyTouchItem(dtv.SelectedItemIndex())
 			},
 
-			// REALLY TEMP
-			"job": func(ctx commandctrl.ExecContext, args []string) tea.Msg {
-				return rc.CountTo10()
-			},
-
 			"echo": func(ctx commandctrl.ExecContext, args []string) tea.Msg {
 				s := new(strings.Builder)
 				for _, arg := range args {

--- a/internal/dynamo-browse/ui/model.go
+++ b/internal/dynamo-browse/ui/model.go
@@ -257,7 +257,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case key.Matches(msg, m.keyMap.PromptForTable):
 				return m, events.SetTeaMessage(m.tableReadController.ListTables())
 			case key.Matches(msg, m.keyMap.CancelRunningJob):
-				return m, events.SetTeaMessage(m.jobController.CancelRunningJob())
+				return m, events.SetTeaMessage(m.jobController.CancelRunningJob(func() tea.Msg {
+					return tea.Quit()
+				}))
 			case key.Matches(msg, m.keyMap.Quit):
 				return m, tea.Quit
 			}

--- a/internal/dynamo-browse/ui/model.go
+++ b/internal/dynamo-browse/ui/model.go
@@ -98,6 +98,23 @@ func NewModel(
 				}
 				return exportController.ExportCSV(args[0])
 			},
+			"mark": func(ctx commandctrl.ExecContext, args []string) tea.Msg {
+				var markOp = controllers.MarkOpMark
+				if len(args) > 0 {
+					switch args[0] {
+					case "all":
+						markOp = controllers.MarkOpMark
+					case "none":
+						markOp = controllers.MarkOpUnmark
+					case "toggle":
+						markOp = controllers.MarkOpToggle
+					default:
+						return events.Error(errors.New("unrecognised mark operation"))
+					}
+				}
+
+				return rc.Mark(markOp)
+			},
 			"unmark": commandctrl.NoArgCommand(rc.Unmark),
 			"delete": commandctrl.NoArgCommand(wc.DeleteMarked),
 

--- a/internal/dynamo-browse/ui/teamodels/colselector/model.go
+++ b/internal/dynamo-browse/ui/teamodels/colselector/model.go
@@ -48,11 +48,11 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.compositor.ClearOverlay()
 	case controllers.ColumnsUpdated:
 		m.colListModel.refreshTable()
-		m.subModel = cc.Collect(m.subModel.Update(msg))
+		m.subModel = cc.Collect(m.subModel.Update(msg)).(tea.Model)
 	case tea.KeyMsg:
 		m.compositor = cc.Collect(m.compositor.Update(msg)).(*layout.Compositor)
 	default:
-		m.subModel = cc.Collect(m.subModel.Update(msg))
+		m.subModel = cc.Collect(m.subModel.Update(msg)).(tea.Model)
 	}
 	return m, cc.Cmd()
 }

--- a/internal/dynamo-browse/ui/teamodels/dynamotableview/colmodel.go
+++ b/internal/dynamo-browse/ui/teamodels/dynamotableview/colmodel.go
@@ -5,6 +5,10 @@ type columnModel struct {
 }
 
 func (cm columnModel) Len() int {
+	if len(cm.m.columns) == 0 {
+		return 0
+	}
+
 	return len(cm.m.columns[cm.m.colOffset:]) + 1
 }
 

--- a/internal/dynamo-browse/ui/teamodels/dynamotableview/model.go
+++ b/internal/dynamo-browse/ui/teamodels/dynamotableview/model.go
@@ -118,6 +118,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m *Model) setLeftmostDisplayedColumn(newCol int) {
+	if m.columnsProvider == nil || m.columnsProvider.Columns() == nil {
+		return
+	}
+
 	if newCol < 0 {
 		m.colOffset = 0
 	} else if newCol >= len(m.columnsProvider.Columns().Columns) {

--- a/internal/dynamo-browse/ui/teamodels/dynamotableview/model.go
+++ b/internal/dynamo-browse/ui/teamodels/dynamotableview/model.go
@@ -205,6 +205,12 @@ func (m *Model) SelectedItemIndex() int {
 
 func (m *Model) selectedItem() (itemTableRow, bool) {
 	resultSet := m.resultSet
+
+	// Fix bug??
+	if m.table.Cursor() < 0 {
+		return itemTableRow{}, false
+	}
+
 	if resultSet != nil && len(m.rows) > 0 {
 		selectedItem, ok := m.table.SelectedRow().(itemTableRow)
 		if ok {

--- a/internal/dynamo-browse/ui/teamodels/dynamotableview/model.go
+++ b/internal/dynamo-browse/ui/teamodels/dynamotableview/model.go
@@ -167,11 +167,8 @@ func (m *Model) rebuildTable(targetTbl *table.Model) {
 
 	// Use the target table model if you can, but if it's nil or the number of rows is smaller than the
 	// existing table, create a new one
-	if targetTbl == nil || len(resultSet.Items()) > len(m.rows) {
+	if targetTbl == nil {
 		tbl = table.New(columnModel{m}, m.w, m.h-m.frameTitle.HeaderHeight())
-		if targetTbl != nil {
-			tbl.GoBottom()
-		}
 	} else {
 		tbl = *targetTbl
 	}
@@ -195,6 +192,7 @@ func (m *Model) rebuildTable(targetTbl *table.Model) {
 
 	m.rows = newRows
 	tbl.SetRows(newRows)
+	tbl.GoTop() // Preserve top and cursor location
 
 	m.table = tbl
 }

--- a/internal/dynamo-browse/ui/teamodels/itemdisplay/model.go
+++ b/internal/dynamo-browse/ui/teamodels/itemdisplay/model.go
@@ -23,7 +23,7 @@ func (m *Model) Init() tea.Cmd {
 func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cc utils.CmdCollector
 
-	m.baseMode = cc.Collect(m.baseMode.Update(msg))
+	m.baseMode = cc.Collect(m.baseMode.Update(msg)).(tea.Model)
 	return m, cc.Cmd()
 }
 

--- a/internal/dynamo-browse/ui/teamodels/layout/zstack.go
+++ b/internal/dynamo-browse/ui/teamodels/layout/zstack.go
@@ -39,10 +39,10 @@ func (vb ZStack) Update(msg tea.Msg) (m tea.Model, cmd tea.Cmd) {
 
 	// All other messages go to each model
 	var cc utils.CmdCollector
-	vb.visibleModel = cc.Collect(vb.visibleModel.Update(msg))
-	vb.focusedModel = cc.Collect(vb.focusedModel.Update(msg))
+	vb.visibleModel = cc.Collect(vb.visibleModel.Update(msg)).(tea.Model)
+	vb.focusedModel = cc.Collect(vb.focusedModel.Update(msg)).(tea.Model)
 	for i, c := range vb.otherModels {
-		vb.otherModels[i] = cc.Collect(c.Update(msg))
+		vb.otherModels[i] = cc.Collect(c.Update(msg)).(tea.Model)
 	}
 	return vb, cc.Cmd()
 }

--- a/internal/dynamo-browse/ui/teamodels/modal/model.go
+++ b/internal/dynamo-browse/ui/teamodels/modal/model.go
@@ -50,16 +50,16 @@ func (m Modal) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg, tea.MouseMsg:
 		// only notify top level stack
 		if len(m.modeStack) > 0 {
-			m.modeStack[len(m.modeStack)-1] = cc.Collect(m.modeStack[len(m.modeStack)-1].Update(msg))
+			m.modeStack[len(m.modeStack)-1] = cc.Collect(m.modeStack[len(m.modeStack)-1].Update(msg)).(tea.Model)
 		} else {
-			m.baseMode = cc.Collect(m.baseMode.Update(msg))
+			m.baseMode = cc.Collect(m.baseMode.Update(msg)).(tea.Model)
 		}
 	default:
 		// notify all modes of other events
 		// TODO: is this right?
-		m.baseMode = cc.Collect(m.baseMode.Update(msg))
+		m.baseMode = cc.Collect(m.baseMode.Update(msg)).(tea.Model)
 		for i, s := range m.modeStack {
-			m.modeStack[i] = cc.Collect(s.Update(msg))
+			m.modeStack[i] = cc.Collect(s.Update(msg)).(tea.Model)
 		}
 	}
 

--- a/internal/dynamo-browse/ui/teamodels/statusandprompt/model.go
+++ b/internal/dynamo-browse/ui/teamodels/statusandprompt/model.go
@@ -37,8 +37,8 @@ func New(model layout.ResizingModel, initialMsg string, style Style) *StatusAndP
 		style:         style,
 		statusMessage: initialMsg,
 		modeLine:      "",
-		//spinner:       spinner.New(spinner.WithSpinner(spinner.Line)),
-		textInput: textInput,
+		spinner:       spinner.New(spinner.WithSpinner(spinner.Line)),
+		textInput:     textInput,
 	}
 }
 
@@ -62,7 +62,6 @@ func (s *StatusAndPrompt) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cc.Add(func() tea.Msg { return msg.Next })
 	case events.ForegroundJobUpdate:
 		if msg.JobRunning {
-			s.spinner = spinner.New(spinner.WithSpinner(spinner.Line))
 			s.spinnerVisible = true
 			s.statusMessage = msg.JobStatus
 			cc.Add(s.spinner.Tick)

--- a/internal/dynamo-browse/ui/teamodels/statusandprompt/model.go
+++ b/internal/dynamo-browse/ui/teamodels/statusandprompt/model.go
@@ -1,6 +1,7 @@
 package statusandprompt
 
 import (
+	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -14,13 +15,15 @@ import (
 // StatusAndPrompt is a resizing model which displays a submodel and a status bar.  When the start prompt
 // event is received, focus will be torn away and the user will be given a prompt the enter text.
 type StatusAndPrompt struct {
-	model         layout.ResizingModel
-	style         Style
-	modeLine      string
-	statusMessage string
-	pendingInput  *events.PromptForInputMsg
-	textInput     textinput.Model
-	width         int
+	model          layout.ResizingModel
+	style          Style
+	modeLine       string
+	statusMessage  string
+	spinner        spinner.Model
+	spinnerVisible bool
+	pendingInput   *events.PromptForInputMsg
+	textInput      textinput.Model
+	width          int
 }
 
 type Style struct {
@@ -29,11 +32,21 @@ type Style struct {
 
 func New(model layout.ResizingModel, initialMsg string, style Style) *StatusAndPrompt {
 	textInput := textinput.New()
-	return &StatusAndPrompt{model: model, style: style, statusMessage: initialMsg, modeLine: "", textInput: textInput}
+	return &StatusAndPrompt{
+		model:         model,
+		style:         style,
+		statusMessage: initialMsg,
+		modeLine:      "",
+		//spinner:       spinner.New(spinner.WithSpinner(spinner.Line)),
+		textInput: textInput,
+	}
 }
 
 func (s *StatusAndPrompt) Init() tea.Cmd {
-	return s.model.Init()
+	return tea.Batch(
+		s.model.Init(),
+		//s.spinner.Tick,
+	)
 }
 
 func (s *StatusAndPrompt) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -47,6 +60,15 @@ func (s *StatusAndPrompt) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case events.WrappedStatusMsg:
 		s.statusMessage = string(msg.Message)
 		cc.Add(func() tea.Msg { return msg.Next })
+	case events.ForegroundJobUpdate:
+		s.statusMessage = msg.JobStatus
+		if msg.JobRunning {
+			s.spinner = spinner.New(spinner.WithSpinner(spinner.Line))
+			s.spinnerVisible = true
+			cc.Add(s.spinner.Tick)
+		} else {
+			s.spinnerVisible = false
+		}
 	case events.ModeMessage:
 		s.modeLine = string(msg)
 	case events.MessageWithStatus:
@@ -92,8 +114,10 @@ func (s *StatusAndPrompt) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 
-	newModel := cc.Collect(s.model.Update(msg))
-	s.model = newModel.(layout.ResizingModel)
+	if s.spinnerVisible {
+		s.spinner = cc.Collect(s.spinner.Update(msg)).(spinner.Model)
+	}
+	s.model = cc.Collect(s.model.Update(msg)).(layout.ResizingModel)
 	return s, cc.Cmd()
 }
 
@@ -120,6 +144,10 @@ func (s *StatusAndPrompt) viewStatus() string {
 		statusLine = s.textInput.View()
 	} else {
 		statusLine = s.statusMessage
+	}
+
+	if s.spinnerVisible {
+		statusLine = lipgloss.JoinHorizontal(lipgloss.Left, s.spinner.View(), " ", statusLine)
 	}
 
 	return lipgloss.JoinVertical(lipgloss.Top, modeLine, statusLine)

--- a/internal/dynamo-browse/ui/teamodels/statusandprompt/model.go
+++ b/internal/dynamo-browse/ui/teamodels/statusandprompt/model.go
@@ -61,10 +61,10 @@ func (s *StatusAndPrompt) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		s.statusMessage = string(msg.Message)
 		cc.Add(func() tea.Msg { return msg.Next })
 	case events.ForegroundJobUpdate:
-		s.statusMessage = msg.JobStatus
 		if msg.JobRunning {
 			s.spinner = spinner.New(spinner.WithSpinner(spinner.Line))
 			s.spinnerVisible = true
+			s.statusMessage = msg.JobStatus
 			cc.Add(s.spinner.Tick)
 		} else {
 			s.spinnerVisible = false

--- a/internal/dynamo-browse/ui/teamodels/statusandprompt/model.go
+++ b/internal/dynamo-browse/ui/teamodels/statusandprompt/model.go
@@ -45,7 +45,6 @@ func New(model layout.ResizingModel, initialMsg string, style Style) *StatusAndP
 func (s *StatusAndPrompt) Init() tea.Cmd {
 	return tea.Batch(
 		s.model.Init(),
-		//s.spinner.Tick,
 	)
 }
 

--- a/internal/dynamo-browse/ui/teamodels/tableselect/model.go
+++ b/internal/dynamo-browse/ui/teamodels/tableselect/model.go
@@ -4,6 +4,7 @@ import (
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/lmika/audax/internal/common/ui/events"
 	"github.com/lmika/audax/internal/dynamo-browse/controllers"
 	"github.com/lmika/audax/internal/dynamo-browse/ui/teamodels/frame"
 	"github.com/lmika/audax/internal/dynamo-browse/ui/teamodels/layout"
@@ -55,7 +56,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					var sel controllers.PromptForTableMsg
 					sel, m.pendingSelection = *m.pendingSelection, nil
 
-					return m, func() tea.Msg { return sel.OnSelected(m.listController.list.SelectedItem().(tableItem).name) }
+					if selTableItem, isTableItem := m.listController.list.SelectedItem().(tableItem); isTableItem {
+						return m, events.SetTeaMessage(sel.OnSelected(selTableItem.name))
+					}
+					return m, events.SetTeaMessage(sel.OnSelected(""))
 				}
 			}
 

--- a/internal/dynamo-browse/ui/teamodels/tableselect/model.go
+++ b/internal/dynamo-browse/ui/teamodels/tableselect/model.go
@@ -67,7 +67,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if m.pendingSelection != nil {
 		m.listController = cc.Collect(m.listController.Update(msg)).(listController)
 	}
-	m.submodel = cc.Collect(m.submodel.Update(msg))
+	m.submodel = cc.Collect(m.submodel.Update(msg)).(tea.Model)
 	return m, cc.Cmd()
 }
 

--- a/internal/dynamo-browse/ui/teamodels/utils/utils.go
+++ b/internal/dynamo-browse/ui/teamodels/utils/utils.go
@@ -12,7 +12,7 @@ func (c *CmdCollector) Add(cmd tea.Cmd) {
 	}
 }
 
-func (c *CmdCollector) Collect(m tea.Model, cmd tea.Cmd) tea.Model {
+func (c *CmdCollector) Collect(m any, cmd tea.Cmd) any {
 	if cmd != nil {
 		c.cmds = append(c.cmds, cmd)
 	}

--- a/internal/ssm-browse/controllers/ssmcontroller.go
+++ b/internal/ssm-browse/controllers/ssmcontroller.go
@@ -77,7 +77,7 @@ func (c *SSMController) Clone(param models.SSMParameter) tea.Msg {
 }
 
 func (c *SSMController) DeleteParameter(param models.SSMParameter) tea.Msg {
-	return events.Confirm("delete parameter? ", func() tea.Msg {
+	return events.ConfirmYes("delete parameter? ", func() tea.Msg {
 		ctx := context.Background()
 		if err := c.service.Delete(ctx, param); err != nil {
 			return events.Error(err)


### PR DESCRIPTION
Added progress indicators and cancellation to all long running operations, such as queries, etc.

- Added new JobController and integrated to the table read and write controller.
- Added progress updates to DynamoDB provider
- Added support for cancelling queries and scans, and providing partial results.
- Added the "mark" command, which can be used to mark and unmark rows.  This replaces the "unmark" command, which is now an alias (also added support for arguments in aliases).