### PR TITLE
scripting: allowed access to environment variables

### DIFF
--- a/internal/dynamo-browse/controllers/scripts.go
+++ b/internal/dynamo-browse/controllers/scripts.go
@@ -65,6 +65,7 @@ func (sc *ScriptController) Init() {
 		OSExecShell: "/bin/bash",
 		Permissions: scriptmanager.Permissions{
 			AllowShellCommands: true,
+			AllowEnv:           true,
 		},
 	})
 }

--- a/internal/dynamo-browse/services/scriptmanager/modos.go
+++ b/internal/dynamo-browse/services/scriptmanager/modos.go
@@ -5,6 +5,7 @@ import (
 	"github.com/cloudcmds/tamarin/arg"
 	"github.com/cloudcmds/tamarin/object"
 	"github.com/cloudcmds/tamarin/scope"
+	"os"
 	"os/exec"
 )
 
@@ -35,12 +36,35 @@ func (om *osModule) exec(ctx context.Context, args ...object.Object) object.Obje
 	return object.NewOkResult(object.NewString(string(out)))
 }
 
+func (om *osModule) env(ctx context.Context, args ...object.Object) object.Object {
+	if err := arg.Require("os.env", 1, args); err != nil {
+		return err
+	}
+
+	cmdEnvName, objErr := object.AsString(args[0])
+	if objErr != nil {
+		return objErr
+	}
+
+	opts := optionFromCtx(ctx)
+	if !opts.Permissions.AllowEnv {
+		return object.Nil
+	}
+
+	envVal, hasVal := os.LookupEnv(cmdEnvName)
+	if !hasVal {
+		return object.Nil
+	}
+	return object.NewString(envVal)
+}
+
 func (om *osModule) register(scp *scope.Scope) {
 	modScope := scope.New(scope.Opts{})
 	mod := object.NewModule("os", modScope)
 
 	modScope.AddBuiltins([]*object.Builtin{
 		object.NewBuiltin("exec", om.exec, mod),
+		object.NewBuiltin("env", om.env, mod),
 	})
 
 	scp.Declare("os", mod, true)

--- a/internal/dynamo-browse/services/scriptmanager/opts.go
+++ b/internal/dynamo-browse/services/scriptmanager/opts.go
@@ -29,6 +29,9 @@ func (opts Options) configuredShell() string {
 type Permissions struct {
 	// AllowShellCommands determines whether or not a script can execute shell commands.
 	AllowShellCommands bool
+
+	// AllowEnv determines whether or not a script can access environment variables
+	AllowEnv bool
 }
 
 type optionCtxKeyType struct{}


### PR DESCRIPTION
Added the `os.env()` module function, which can be used to get the value of an environment variable.

This is controlled under runtime permissions.